### PR TITLE
Fully utilize allocated threads

### DIFF
--- a/alphaSat-HMMER/alphaSat-HMMER.wdl
+++ b/alphaSat-HMMER/alphaSat-HMMER.wdl
@@ -149,21 +149,17 @@ task alphaSat_HMMER {
 		## localize hmmertblout2bed script (needed for hmmer run calls)
 		ln -s /opt/HumAS-HMMER_for_AnVIL/hmmertblout2bed.awk .
 
-
-		## Set number of threads (reserve one thread for master node)
-		NHMMER_THREADS=$((~{threadCount} - 1))
-
 		## Troubleshoot slow runtime
 		date 
 
 		## Run HumAS-HMMER, output: AS-HOR+SF, AS-HOR, AS-strand
-		hmmer-run.sh input_fasta_dir ~{hmm_profile} ${NHMMER_THREADS}
+		hmmer-run.sh input_fasta_dir ~{hmm_profile} ~{threadCount}
 
 		## Troubleshoot slow runtime
 		date 
 
 		## Run HumAS-HMMER, output: AS-SF
-		hmmer-run_SF.sh input_fasta_dir ~{hmm_profile_SF} ${NHMMER_THREADS}
+		hmmer-run_SF.sh input_fasta_dir ~{hmm_profile_SF} ~{threadCount}
 
 		## Troubleshoot slow runtime
 		date 

--- a/cenSatAnnotation/tasks/RepeatMasker.wdl
+++ b/cenSatAnnotation/tasks/RepeatMasker.wdl
@@ -108,8 +108,11 @@ task maskContig {
         set -e
         set -u
         set -o xtrace
+        
+        # each parallel job uses 4 threads, budget 4 threads per job, rounding up
+        NPARALLEL=$(( (~{threadCount} + 3) / 4 ))
 
-        RepeatMasker -s -pa 8 -e ncbi ~{subsequence} -dir .
+        RepeatMasker -s -pa ${NPARALLEL} -e ncbi ~{subsequence} -dir .
         # for small contigs - if there are no repeats found put the unmasked sequence in and create a dummy 
         if ! test -f ~{subsequenceName}.masked; then cat ~{subsequence} > ~{subsequenceName}.masked \
         && touch ~{subsequenceName}.tbl \


### PR DESCRIPTION
The HMMER step was needlessly restricting its thread use. It should now run a bit faster. I also removed a hard-coded thread use for RepeatMasker that ignored the task configuration. The core usage was set correctly for the default thread value, so this should not affect run time unless we change the shape of the allocated machines.