### PR TITLE
Combine in parts

### DIFF
--- a/alphaSat-HMMER/alphaSat-HMMER.wdl
+++ b/alphaSat-HMMER/alphaSat-HMMER.wdl
@@ -229,7 +229,7 @@ task combine_beds {
 	>>>
 
 	output {
-		File output_bed  = output_bed
+		File output_bed  = out_bed_fn
 	}
 
 	runtime {

--- a/cenSatAnnotation/centromereAnnotation.wdl
+++ b/cenSatAnnotation/centromereAnnotation.wdl
@@ -47,7 +47,7 @@ workflow centromereAnnotation {
             input_fasta=formatAssembly.formattedFasta,
             hmm_profile=AS_hmm_profile,
             hmm_profile_SF=AS_hmm_profile_SF,
-            sample_id=fName
+            assembly_id=fName
     }
 
     call finalizeCenSat.cenSatAnnotation as cenSatAnnotation {


### PR DESCRIPTION
* combine asat HMM beds by type
* summarize alpha as separate task
* switched sample_id to assembly_id
* move asat file naming to more standard {assembly_id}_{type}.bed
* got rid of "vs" naming in asat files
