### PR TITLE
Parallelizing tasks with a fixed number of fasta files

### DIFF
--- a/cenSatAnnotation/tasks/CenSatAnnotation.wdl
+++ b/cenSatAnnotation/tasks/CenSatAnnotation.wdl
@@ -200,7 +200,7 @@ task createAnnotations {
         bedtools sort -i HSAT23.bed > HSAT23.sorted.bed
 
         # Merge any rDNA annotations that are adjacent to the gaps 
-        cat ~{rDNABed} ~{gapBed} | bedtools sort -i stdin | bedtools merge -d 40000 -i stdin | awk 'BEGIN{OFS="\t"} {print $1, $2, $3, "rDNA", "0", ".", $2, $3, "102,47,144"}' > rDNA.merged.bed 
+        cat ~{rDNABed} ~{gapBed} | awk '{print $1"\t"$2"\t"$3}' | bedtools sort -i stdin | bedtools merge -d 40000 -i stdin | awk 'BEGIN{OFS="\t"} {print $1, $2, $3, "rDNA", "0", ".", $2, $3, "102,47,144"}' > rDNA.merged.bed 
 
         # now resolve any existing overlaps within any of the files and record any instances of overlaps 
         # first find overlaps and add to final tracking file 

--- a/cenSatAnnotation/tasks/rDNA_annotation.wdl
+++ b/cenSatAnnotation/tasks/rDNA_annotation.wdl
@@ -47,24 +47,54 @@ task createArray {
     input {
         File fasta
         String fName
+        Int numberOfOutputs = 16
+
+        Int threadCount = 2
+        Int memSizeGB   = 16
+        Int diskSize    = 32
+        Int preemptible = 1
     }
     command <<<
 
-    # unzip the fasta if it is zipped 
-        if [[ ~{fasta} =~ \.gz$ ]] ; then
-            gunzip -fc ~{fasta} > ~{fName}.fa 
-        else 
-            cat ~{fasta} > ~{fName}.fa 
-        fi
-    
-    awk '/^>/ { file=substr($1,2) ".fa" } { print > file }' ~{fName}.fa
+        ## first check if assembly_fa needs to be unzipped 
+        if [[ ~{fasta} =~ \.gz$ ]]; then
+            gunzip -fc ~{fasta} > ~{fName}.fa
+        else
+            cat ~{fasta} > ~{fName}.fa
+        fi 
+
+        samtools faidx  ~{fName}.fa
+        cat ~{fName}.fa.fai | awk '{print $1"\t0\t"$2}' | bedtools sort -i - > ~{fName}.bed
+
+        # this script will split the whole genome bed file into as many bed files as requested (default 16)
+        # without splitting any contig it keeps either a whole config in each bed file or none of it
+        # the total length of the output bed files are as close as possible to each other to make sure
+        # running the following tasks on one split does not take way longer than others
+        mkdir -p output 
+        python3 ${SPLIT_BED_CONTIG_WISE_PY} \
+            --bed ~{fName}.bed  \
+            --n ~{numberOfOutputs} \
+            --dir output \
+            --prefix ~{fName}
+
+        # create one fasta per bed file
+        for BED in $(find output)
+        do
+            cat ${BED} | \
+                cut -f1 | \
+                seqtk subseq ~{fName}.fa  - > ${BED%%.bed}.fa 
+        done
 
     >>>
     output {
-        Array[File] contigArray = glob("*.fa")
+        Array[File] contigArray = glob("output/*.fa")
     }
     runtime {
-        docker: "ubuntu:18.04"
+        cpu: threadCount        
+        memory: memSizeGB + " GB"
+        disks: "local-disk " + diskSize + " SSD"
+        docker: "mobinasri/flagger:v1.1.0"
+        preemptible : preemptible
     }
 }
 


### PR DESCRIPTION
The reason for this pull request is very similar to https://github.com/human-pangenomics/hpp_production_workflows/pull/27
That pull request was not enough for fixing the parallelization issues I encountered for some assemblies.
Here the workflow is splitting the given fasta file for parallelizing running HMMER in two different parts; once for rDNA annotation and once for HOR annotation. I just copied the task I used in the pull request mentioned above to these two parts to split the input fasta into a fixed number of fasta files. It fixed the error I encountered while running the workflow for HG002-T2T-v0.7 assembly (haplotype 1). For future I recommend putting this task in a separate wdl and importing that into any other wdl where we want to call that task. This way whenever we want to modify this task we don't have to apply the changes to multiple the places.